### PR TITLE
fix: #52 덱 설정 모달 내 select element 선택 값 미출력 이슈 수정

### DIFF
--- a/src/deck/DeckEditFormDialog.tsx
+++ b/src/deck/DeckEditFormDialog.tsx
@@ -161,7 +161,7 @@ export function DeckEditFormDialog({ deck, children }: DeckEditFormDialog) {
               onValueChange={(value) =>
                 setSelectDirectory(Number.parseInt(value))
               }
-              value={deck?.folderId.toString() ?? ""}
+              defaultValue={deck?.folderId.toString() ?? ""}
             >
               <SelectTrigger id="folder" className="min-h-[44px]">
                 <SelectValue placeholder="선택" />
@@ -184,7 +184,7 @@ export function DeckEditFormDialog({ deck, children }: DeckEditFormDialog) {
               onValueChange={(value) =>
                 setSelectCategory(Number.parseInt(value))
               }
-              value={deck?.categoryId.toString() ?? ""}
+              defaultValue={deck?.categoryId.toString() ?? ""}
             >
               <SelectTrigger id="category" className="min-h-[44px]">
                 <SelectValue placeholder="선택" />


### PR DESCRIPTION
- 덱 수정 시 기존 값 출력을 위해 value props 사용하여 값을 고정시켜버려서 발생한 문제
    - value props가 아닌 defaultValue props로 변경

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
덱 수정 모달 활성화 시 기존 값 출력을 위해 select props에 defaultValue가 아닌 value로 지정해둬 값이 고정된 문제 발생

### 📝 Checklist
- [x] 🔴 Human eyes (no test)
- [ ] 🟡 swagger or Smoke test
- [ ] 🟢 unit test or CI test

### 📸 Log/Screenshot
🏡 after
![image](https://github.com/user-attachments/assets/d221a813-70bc-42ae-90a0-31665fcc80e1)

